### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine
+FROM ocaml/opam:alpine-ocaml-5.4
 USER root
 LABEL org.opencontainers.image.source=https://github.com/kuis-isle3sw/ocaml-docker
 RUN apk add m4

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ USER root
 LABEL org.opencontainers.image.source=https://github.com/kuis-isle3sw/ocaml-docker
 RUN apk add m4
 RUN opam init --disable-sandboxing -y
-RUN opam install menhir dune ounit -y --verbose
+RUN opam install menhir dune ounit2 -y --verbose
 RUN echo $'#!/bin/bash -ex\n\
 eval $(opam env)' > /root/.bash_profile
 RUN chmod +rx /root/.bash_profile


### PR DESCRIPTION
- Docker のベースイメージの更新
- 現在は ounit は `opam install ounit2` としてインストールすべきらしいので修正
    - c.f.: https://github.com/gildor478/ounit

Fixes: #7 